### PR TITLE
Fixed navbar scrolling

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -25,11 +25,6 @@ body {
   position: relative;
 }
 
-body,
-html {
-  height: 100%;
-}
-
 .nav .open>a,
 .nav .open>a:hover,
 .nav .open>a:focus {
@@ -642,7 +637,6 @@ a[href*="#followme"]::before {
 
 .hamburger {
   position: fixed;
-  top: 30px;
   z-index: 999;
   display: block;
   width: 32px;


### PR DESCRIPTION
### The functionality of hiding navbar based on scrolling (pull #99) broke due to addition of hamburger (pull #103). Also, now the hamburger (un)hides with scrolling

#### 1. Fixing navbar
```
body,
html {
  height: 100%;
}
```
Due to height, `$(window).scroll()` stopped working, thus the functionality broke. This CSS sets the document to not show overflow therefore the document itself isn't scrolling.

#### 2. Fixing hamburger
Removing `top: 30px;` from `.hamburger` allowed the hamburger to (un)hide with the navbar. Initially, it stayed at its position.