### PR TITLE
Imp/index laptop

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -7,6 +7,7 @@
 var app = require('../app');
 var debug = require('debug')('myhoganexpressapp:server');
 var http = require('http');
+var opn = require('opn');
 
 /**
  * Get port from environment and store in Express.
@@ -87,5 +88,6 @@ function onListening() {
   var bind = typeof addr === 'string'
     ? 'pipe ' + addr
     : 'port ' + addr.port;
-  debug('Listening on ' + bind);
+  console.log('Listening on http://localhost:5000');
+  opn('http://localhost:5000');
 }

--- a/bin/www
+++ b/bin/www
@@ -85,9 +85,5 @@ function onError(error) {
 function onListening() {
   var addr = server.address();
   console.log("Web Server running on port "+ addr.port);
-  var bind = typeof addr === 'string'
-    ? 'pipe ' + addr
-    : 'port ' + addr.port;
-  console.log('Listening on http://localhost:5000');
-  opn('http://localhost:5000');
+  opn('http://localhost:' + addr.port);
 }

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -29,8 +29,7 @@ nav {
 nav li {
     display: inline-block;
     margin: 0 3px;
-    min-width: 90px;
-    width: 12%;
+    min-width: 15%;
 }
 
 nav ul {
@@ -51,7 +50,9 @@ nav a {
     font-size: 21px;
 }
 
-nab .brand {}
+.brand {
+  text-align: center;
+}
 
 nav .brand img {
     background-color: #fff;
@@ -189,7 +190,7 @@ nav .brand img {
 }
 
 .factsHead{
-    
+
 }
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,9 @@
   <header>
     <nav>
       <div class="wrapper">
+        <a href="/" class="brand">
+          <img src="/assets/images/logo.png" alt="">
+        </a>
         <ul>
           <li>
             <a href="">About</a>
@@ -42,11 +45,6 @@
           </li>
           <li>
             <a href="">Eligibility</a>
-          </li>
-          <li>
-            <a class="brand">
-              <img src="/assets/images/logo.png" alt="">
-            </a>
           </li>
           <li>
             <a href="">How to donate?</a>
@@ -144,8 +142,8 @@
               <span>5).</span>
               <p>Cancer patients may require blood transfusion, especially when they are under chemotherapy (treatment which affects blood cells) or stem cell transplants. Many chemotherapy medicines and the disease itself can sometimes interfere with normal production of blood cells in the bone marrow.</p>
             </li>
-            
-           
+
+
           </ul>
           </div>
         </div>


### PR DESCRIPTION
The logo in `index.html` was not center aligned. Also, for Laptops with MiPDI screen, the `How to Donate?` would split into into parts. Screenshots are included below for reference.
Made changes to `bin/www` so that when we run `heroku local`, the web server is opened.

![jeevanrakht herokuapp com_index html laptop with mdpi screen](https://user-images.githubusercontent.com/30711246/39965982-763129e6-56c1-11e8-92c0-5b96288e2bda.png)
![localhost_5000_index html laptop with hidpi screen](https://user-images.githubusercontent.com/30711246/39965983-765d39d2-56c1-11e8-9424-d3772a14f269.png)
